### PR TITLE
Fix readme example description

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ await cli.prompt('What is your name?')
 // mask input after enter is pressed
 await cli.prompt('What is your two-factor token?', {type: 'mask'})
 
-// mask input after enter is pressed
+// mask input on keypress (before enter is pressed)
 await cli.prompt('What is your password?', {type: 'hide'})
 ```
 


### PR DESCRIPTION
Just by instance I just saw you added some examples here, but figured the explanation was wrong for the last one (according to the GIF)