### PR TITLE
Move `@oclif/errors` into `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Jeff Dickey @jdxcode",
   "bugs": "https://github.com/oclif/cli-ux/issues",
   "dependencies": {
+    "@oclif/errors": "^1.2.0",
     "@oclif/linewrap": "^1.0.0",
     "@oclif/screen": "^1.0.2",
     "ansi-styles": "^3.2.1",
@@ -24,7 +25,6 @@
     "supports-hyperlinks": "^1.0.1"
   },
   "devDependencies": {
-    "@oclif/errors": "^1.2.0",
     "@oclif/tslint": "^2.0.0",
     "@types/ansi-styles": "^3.2.0",
     "@types/chai": "^4.1.4",


### PR DESCRIPTION
Currently, `@oclif/errors` is in `devDependencies`, so when I `npm install cli-ux`, `@oclif/errors` is not available in `node_modules` which throws the following error:
```
Error: Cannot find module '@oclif/errors'
```
Doing a manual `npm i @oclif/errors` and then running the code is working.

This PR moves it to `dependencies` so that it'll be available in `node_modules`.
