### PR TITLE
Table: Allow data to be filtered even if the column is not displayed

### DIFF
--- a/src/styled/table.ts
+++ b/src/styled/table.ts
@@ -29,15 +29,6 @@ class Table<T extends object> {
       }
     })
 
-    // and filter columns
-    if (options.columns) {
-      let filters = options.columns!.split(',')
-      this.columns = this.filterColumnsFromHeaders(filters)
-    } else if (!options.extended) {
-      // show extented columns/properties
-      this.columns = this.columns.filter(c => !c.extended)
-    }
-
     // assign options
     const {columns: cols, filter, csv, extended, sort, printLine} = options
     this.options = {
@@ -88,6 +79,15 @@ class Table<T extends object> {
       })
       let sortKeysOrder = sorters.map(k => k[0] === '-' ? 'desc' : 'asc')
       rows = orderBy(rows, sortKeys, sortKeysOrder)
+    }
+
+    // and filter columns
+    if (this.options.columns) {
+      let filters = this.options.columns!.split(',')
+      this.columns = this.filterColumnsFromHeaders(filters)
+    } else if (!this.options.extended) {
+      // show extented columns/properties
+      this.columns = this.columns.filter(c => !c.extended)
     }
 
     this.data = rows


### PR DESCRIPTION
When using table, if we try to filter on a specific column but displaying only another one we have the following error.
```bash
cli git:(master) ✗ bin/run service:list --filter="STATUS=started" --columns HASH --no-header
Error: Filter flag has an invalid value
    at Table.display (~/prog/MESG/cli/node_modules/cli-ux/lib/styled/table.js:71:23)
    at Object.table (~/prog/MESG/cli/node_modules/cli-ux/lib/styled/table.js:226:39)
    at ServiceList.run (~/prog/MESG/cli/src/commands/service/list.ts:17:9)
```

This is something useful basically to filter based on the data but only get the id in order to chain the commands eg: `cli delete $(cli list --filter XXX=yyy --no-header --columns=id)`