### PR TITLE
Eliminate tty check on stdin

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,6 @@ const g: any = global
 const globals = g['cli-ux'] || (g['cli-ux'] = {})
 
 const actionType = (
-  !!process.stdin.isTTY &&
   !!process.stderr.isTTY &&
   !process.env.CI &&
   !['dumb', 'emacs-color'].includes(process.env.TERM!) &&


### PR DESCRIPTION
Whether stdin is a TTY should have no bearing on whether or not the spinner is displayed. For example: `cat <file> | my-tool` should still be able to display a spinner. Currently, the spinner gets disabled in this case because stdin is not a tty.