### PR TITLE
fix: enabling --no-headers in --csv

### DIFF
--- a/src/styled/table.ts
+++ b/src/styled/table.ts
@@ -115,7 +115,9 @@ class Table<T extends object> {
     // tslint:disable-next-line:no-this-assignment
     const {data, columns, options} = this
 
-    options.printLine(columns.map(c => c.header).join(','))
+    if (!options['no-header']) {
+      options.printLine(columns.map(c => c.header).join(','))
+    }
     data.forEach((d: any) => {
       let row: string[] = []
       columns.forEach(col => row.push(d[col.key] || ''))
@@ -239,7 +241,7 @@ export namespace table {
     columns: F.string({exclusive: ['extended'], description: 'only show provided columns (comma-separated)'}),
     sort: F.string({description: 'property to sort by (prepend \'-\' for descending)'}),
     filter: F.string({description: 'filter property by partial string matching, ex: name=foo'}),
-    csv: F.boolean({exclusive: ['no-truncate', 'no-header'], description: 'output is csv format'}),
+    csv: F.boolean({exclusive: ['no-truncate'], description: 'output is csv format'}),
     extended: F.boolean({exclusive: ['columns'], char: 'x', description: 'show extra columns'}),
     'no-truncate': F.boolean({exclusive: ['csv'], description: 'do not truncate output to fit screen'}),
     'no-header': F.boolean({exclusive: ['csv'], description: 'hide table header from output'}),

--- a/test/styled/table.test.ts
+++ b/test/styled/table.test.ts
@@ -148,6 +148,14 @@ describe('styled/table', () => {
 
     fancy
       .stdout()
+      .end('outputs in csv without headers', output => {
+        cli.table(apps, columns, {csv: true, 'no-header': true})
+        expect(output.stdout).to.equal(`123,supertable-test-1
+321,supertable-test-2\n`)
+      })
+
+    fancy
+      .stdout()
       .end('sorts by property', output => {
         cli.table(apps, columns, {sort: '-name'})
         expect(output.stdout).to.equal(`ID  Name${ws.padEnd(14)}


### PR DESCRIPTION
A non-header csv is valid according to [RFC-4180](https://tools.ietf.org/html/rfc4180)