### PR TITLE
fix: csv generation now escape problematic values

### DIFF
--- a/src/styled/table.ts
+++ b/src/styled/table.ts
@@ -111,14 +111,26 @@ class Table<T extends object> {
     return cols
   }
 
+  private getCSVRow(d: any): string[] {
+    const values = this.columns.map(col => d[col.key] || '')
+
+    const needToBeEscapedForCsv = (e: string) => {
+      // CSV entries containing line breaks, comma or double quotes
+      // as specified in https://tools.ietf.org/html/rfc4180#section-2
+      return e.includes('"') || e.includes('\n') || e.includes('\r\n') || e.includes('\r') || e.includes(',')
+    }
+
+    const lineToBeEscaped = values.find(needToBeEscapedForCsv)
+    return values.map(e => lineToBeEscaped ? `"${e.replace('"', '""')}"` : e)
+  }
+
   private outputCSV() {
     // tslint:disable-next-line:no-this-assignment
     const {data, columns, options} = this
 
     options.printLine(columns.map(c => c.header).join(','))
     data.forEach((d: any) => {
-      let row: string[] = []
-      columns.forEach(col => row.push(d[col.key] || ''))
+      const row = this.getCSVRow(d)
       options.printLine(row.join(','))
     })
   }

--- a/test/styled/table.test.ts
+++ b/test/styled/table.test.ts
@@ -148,6 +148,34 @@ describe('styled/table', () => {
 
     fancy
       .stdout()
+      .end('outputs in csv with escaped values', output => {
+        cli.table([
+          {
+            id: '123\n2',
+            name: 'supertable-test-1',
+          },
+          {
+            id: '12"3',
+            name: 'supertable-test-2',
+          },
+          {
+            id: '123',
+            name: 'supertable-test-3,comma',
+          },
+          {
+            id: '123',
+            name: 'supertable-test-4',
+          },
+        ], columns, {csv: true})
+        expect(output.stdout).to.equal(`ID,Name
+"123\n2","supertable-test-1"
+"12""3","supertable-test-2"
+"123","supertable-test-3,comma"
+123,supertable-test-4\n`)
+      })
+
+    fancy
+      .stdout()
       .end('sorts by property', output => {
         cli.table(apps, columns, {sort: '-name'})
         expect(output.stdout).to.equal(`ID  Name${ws.padEnd(14)}

--- a/test/styled/table.test.ts
+++ b/test/styled/table.test.ts
@@ -172,7 +172,8 @@ describe('styled/table', () => {
 "12""3","supertable-test-2"
 "123","supertable-test-3,comma"
 123,supertable-test-4\n`)
-    
+      })
+
     fancy
       .stdout()
       .end('outputs in csv without headers', output => {


### PR DESCRIPTION
Escaping conforming to [RFC-4180](https://tools.ietf.org/html/rfc4180)

Fixes #105 