### PR TITLE
fix: The new progress bar feature (PR #131) doesn't show any output w…

### DIFF
--- a/src/styled/progress.ts
+++ b/src/styled/progress.ts
@@ -7,7 +7,7 @@ export default function progress(options?: any): any {
     options = {}
   }
   // set noTTYOutput for options
-  options.noTTYOutput = Boolean(process.env.TERM !== 'dumb' && process.stdin.isTTY)
+  options.noTTYOutput = Boolean(process.env.TERM === 'dumb' || !process.stdin.isTTY)
 
   return new cliProgress.SingleBar(options)
 }


### PR DESCRIPTION
fix: The new progress bar feature (PR #131) doesn't show any output when the process is not TTY. The cli-progress library supports no TTY output but it has to be enabled with the noTTYOutput option.

The logic is currently - enable no TTY output if the terminal is not dumb and the process is TTY which seems to be the wrong way around. This should be 'enable no TTY output' if the terminal is dumb or the process is not TTY i.e. the terminal is dumb or not interactive (i.e. as part of a CI process). (#137)