### PR TITLE
fix: use util.inspect instead of JSON.stringify

### DIFF
--- a/src/styled/json.ts
+++ b/src/styled/json.ts
@@ -1,11 +1,12 @@
 // tslint:disable restrict-plus-operands
 
 import chalk from 'chalk'
+import util from 'util'
 
 import cli from '..'
 
 export default function styledJSON(obj: any) {
-  const json = JSON.stringify(obj, null, 2)
+  const json = util.inspect(obj)
   if (!chalk.enabled) {
     cli.info(json)
     return


### PR DESCRIPTION
Fixes issue with circular structures in JSON:

```
TypeError: Converting circular structure to JSON

  at JSON.stringify (<anonymous>)

  at Object.styledJSON (~/.local/share/sfdx/node_modules/cli-ux/lib/styled/json.js:8:21)

  at UX.logJson (~/.local/share/sfdx/node_modules/@salesforce/command/lib/ux.js:101:18)

  at UserCreateCommand.finally (~/.local/share/sfdx/node_modules/@salesforce/command/lib/sfdxCommand.js:305:25)

  at UserCreateCommand._run (~/.local/share/sfdx/node_modules/@salesforce/command/lib/sfdxCommand.js:98:31)
```