### PR TITLE
Fix: do not cache require, require is already cached in NodeJS by design

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-missing-require */
 export default {
   get stripAnsi(): (string: string) => string {
     return require('strip-ansi')

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,56 +1,44 @@
-const cache: any = {}
-
-function fetch(s: string) {
-  if (!cache[s]) {
-    cache[s] = require(s)
-  }
-  return cache[s]
-}
-
-export const deps = {
+export default {
   get stripAnsi(): (string: string) => string {
-    return fetch('strip-ansi')
+    return require('strip-ansi')
   },
   get ansiStyles(): typeof import('ansi-styles') {
-    return fetch('ansi-styles')
+    return require('ansi-styles')
   },
   get ansiEscapes(): any {
-    return fetch('ansi-escapes')
+    return require('ansi-escapes')
   },
   get passwordPrompt(): any {
-    return fetch('password-prompt')
+    return require('password-prompt')
   },
   get screen(): typeof import('@oclif/screen') {
-    return fetch('@oclif/screen')
+    return require('@oclif/screen')
   },
-
   get open(): typeof import('./open').default {
-    return fetch('./open').default
+    return require('./open').default
   },
   get prompt(): typeof import('./prompt') {
-    return fetch('./prompt')
+    return require('./prompt')
   },
   get styledObject(): typeof import('./styled/object').default {
-    return fetch('./styled/object').default
+    return require('./styled/object').default
   },
   get styledHeader(): typeof import('./styled/header').default {
-    return fetch('./styled/header').default
+    return require('./styled/header').default
   },
   get styledJSON(): typeof import('./styled/json').default {
-    return fetch('./styled/json').default
+    return require('./styled/json').default
   },
   get table(): typeof import('./styled/table').table {
-    return fetch('./styled/table').table
+    return require('./styled/table').table
   },
   get tree(): typeof import('./styled/tree').default {
-    return fetch('./styled/tree').default
+    return require('./styled/tree').default
   },
   get wait(): typeof import('./wait').default {
-    return fetch('./wait').default
+    return require('./wait').default
   },
   get progress(): typeof import ('./styled/progress').default {
-    return fetch('./styled/progress').default
+    return require('./styled/progress').default
   },
 }
-
-export default deps


### PR DESCRIPTION
In `deps.ts` several dependencies are being cached to a local object. As [NodeJS by design caches require calls](https://nodejs.org/api/modules.html#modules_require_id) the caching done in `deps.ts` does not offer performance benefit. Instead it causes problems when using `cli-ux` together with webpack or rollup for which at this time there is no simple fix.

I think it might be better to replace all calls to deps.ts with standard require calls, but as that is a bigger change I first wanted to check if that is appriciated before I will start making those changes :)