### PR TITLE
Add documentation for non-required prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ await cli.prompt('What is your two-factor token?', {type: 'mask'})
 // mask input on keypress (before enter is pressed)
 await cli.prompt('What is your password?', {type: 'hide'})
 
+// prompt that isn't required, user can press enter and move onto the next prompt 
+await cli.prompt('(Optional) What is your email address?', {required: false})
+
 // yes/no confirmation
 await cli.confirm('Continue?')
 


### PR DESCRIPTION
Added documentation for `{required: false}` in `cli.prompt`
I was looking for that and couldn't find it. Saw the PR which added feature, and then later added it to the docs. 