### PR TITLE
feat: add title to tables and improve output structure

### DIFF
--- a/src/styled/table.ts
+++ b/src/styled/table.ts
@@ -42,6 +42,7 @@ class Table<T extends object> {
       'no-header': options['no-header'] || false,
       'no-truncate': options['no-truncate'] || false,
       printLine: printLine || ((s: any) => process.stdout.write(s + '\n')),
+      rowStart: ' ',
       sort,
       title,
     }
@@ -242,11 +243,13 @@ class Table<T extends object> {
       options.printLine(options.title)
       // print title divider
       options.printLine(''.padEnd(columns.reduce((sum, col) => sum + col.width!, 1), '='))
+
+      options.rowStart = '| '
     }
 
     // print headers
     if (!options['no-header']) {
-      let headers = '| '
+      let headers = options.rowStart
       for (const col of columns) {
         const header = col.header!
         headers += header.padEnd(col.width!)
@@ -254,9 +257,9 @@ class Table<T extends object> {
       options.printLine(chalk.bold(headers))
 
       // print header dividers
-      let dividers = '| '
+      let dividers = options.rowStart
       for (const col of columns) {
-        const divider = ''.padEnd(col.maxWidth! - 1, '-') + ' '
+        const divider = ''.padEnd(col.maxWidth! - 1, '─') + ' '
         dividers += divider.padEnd(col.width!)
       }
       options.printLine(chalk.bold(dividers))
@@ -278,7 +281,7 @@ class Table<T extends object> {
       // print row
       // including multi-lines
       linesIndexess.forEach((i: number) => {
-        let l = '| '
+        let l = options.rowStart
         for (const col of columns) {
           const width = col.width!
           let d = (row as any)[col.key]

--- a/src/styled/table.ts
+++ b/src/styled/table.ts
@@ -33,7 +33,7 @@ class Table<T extends object> {
     })
 
     // assign options
-    const {columns: cols, filter, csv, output, extended, sort, printLine} = options
+    const {columns: cols, filter, csv, output, extended, sort, title, printLine} = options
     this.options = {
       columns: cols,
       output: csv ? 'csv' : output,
@@ -43,6 +43,7 @@ class Table<T extends object> {
       'no-truncate': options['no-truncate'] || false,
       printLine: printLine || ((s: any) => process.stdout.write(s + '\n')),
       sort,
+      title,
     }
   }
 
@@ -236,14 +237,29 @@ class Table<T extends object> {
     }
     shouldShorten()
 
+    // print table title
+    if (options.title) {
+      options.printLine(options.title)
+      // print title divider
+      options.printLine(''.padEnd(columns.reduce((sum, col) => sum + col.width!, 1), '='))
+    }
+
     // print headers
     if (!options['no-header']) {
-      let headers = ''
+      let headers = '| '
       for (const col of columns) {
         const header = col.header!
         headers += header.padEnd(col.width!)
       }
       options.printLine(chalk.bold(headers))
+
+      // print header dividers
+      let dividers = '| '
+      for (const col of columns) {
+        const divider = ''.padEnd(col.maxWidth! - 1, '-') + ' '
+        dividers += divider.padEnd(col.width!)
+      }
+      options.printLine(chalk.bold(dividers))
     }
 
     // print rows
@@ -262,7 +278,7 @@ class Table<T extends object> {
       // print row
       // including multi-lines
       linesIndexess.forEach((i: number) => {
-        let l = ''
+        let l = '| '
         for (const col of columns) {
           const width = col.width!
           let d = (row as any)[col.key]

--- a/test/styled/table.test.ts
+++ b/test/styled/table.test.ts
@@ -90,10 +90,10 @@ describe('styled/table', () => {
   .stdout()
   .end('displays table', output => {
     cli.table(apps, columns)
-    expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
-| --- -----------------${ws}
-| 123 supertable-test-1${ws}
-| 321 supertable-test-2${ws}\n`)
+    expect(output.stdout).to.equal(` ID  Name${ws.padEnd(14)}
+ ─── ─────────────────${ws}
+ 123 supertable-test-1${ws}
+ 321 supertable-test-2${ws}\n`)
   })
 
   describe('columns', () => {
@@ -101,17 +101,17 @@ describe('styled/table', () => {
     .stdout()
     .end('use header value for id', output => {
       cli.table(apps, columns)
-      expect(output.stdout.slice(2, 4)).to.equal('ID')
+      expect(output.stdout.slice(1, 3)).to.equal('ID')
     })
 
     fancy
     .stdout()
     .end('shows extended columns/uses get() for value', output => {
       cli.table(apps, columns, {extended: true})
-      expect(output.stdout).to.equal(`|${ws}${extendedHeader}
-| --- ----------------- ---------------------------------------- ---------${ws}
-| 123 supertable-test-1 https://supertable-test-1.herokuapp.com/ heroku-16${ws}
-| 321 supertable-test-2 https://supertable-test-2.herokuapp.com/ heroku-16${ws}\n`)
+      expect(output.stdout).to.equal(`${ws}${extendedHeader}
+ ─── ───────────────── ──────────────────────────────────────── ─────────${ws}
+ 123 supertable-test-1 https://supertable-test-1.herokuapp.com/ heroku-16${ws}
+ 321 supertable-test-2 https://supertable-test-2.herokuapp.com/ heroku-16${ws}\n`)
     })
   })
 
@@ -125,20 +125,32 @@ describe('styled/table', () => {
 
     fancy
     .stdout()
+    .end('shows title with divider', output => {
+      cli.table(apps, columns, {title: 'testing'})
+      expect(output.stdout).to.equal(`testing
+=======================
+| ID  Name${ws.padEnd(14)}
+| ─── ─────────────────${ws}
+| 123 supertable-test-1${ws}
+| 321 supertable-test-2${ws}\n`)
+    })
+
+    fancy
+    .stdout()
     .end('skips header', output => {
       cli.table(apps, columns, {'no-header': true})
-      expect(output.stdout).to.equal(`| 123 supertable-test-1${ws}
-| 321 supertable-test-2${ws}\n`)
+      expect(output.stdout).to.equal(` 123 supertable-test-1${ws}
+ 321 supertable-test-2${ws}\n`)
     })
 
     fancy
     .stdout()
     .end('only displays given columns', output => {
       cli.table(apps, columns, {columns: 'id'})
-      expect(output.stdout).to.equal(`| ID${ws}${ws}
-| ---${ws}
-| 123${ws}
-| 321${ws}\n`)
+      expect(output.stdout).to.equal(` ID${ws}${ws}
+ ───${ws}
+ 123${ws}
+ 321${ws}\n`)
     })
 
     fancy
@@ -228,19 +240,19 @@ describe('styled/table', () => {
     .stdout()
     .end('sorts by property', output => {
       cli.table(apps, columns, {sort: '-name'})
-      expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
-| --- -----------------${ws}
-| 321 supertable-test-2${ws}
-| 123 supertable-test-1${ws}\n`)
+      expect(output.stdout).to.equal(` ID  Name${ws.padEnd(14)}
+ ─── ─────────────────${ws}
+ 321 supertable-test-2${ws}
+ 123 supertable-test-1${ws}\n`)
     })
 
     fancy
     .stdout()
     .end('filters by property & value (partial string match)', output => {
       cli.table(apps, columns, {filter: 'id=123'})
-      expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
-| --- -----------------${ws}
-| 123 supertable-test-1${ws}\n`)
+      expect(output.stdout).to.equal(` ID  Name${ws.padEnd(14)}
+ ─── ─────────────────${ws}
+ 123 supertable-test-1${ws}\n`)
     })
 
     fancy
@@ -248,9 +260,9 @@ describe('styled/table', () => {
     .end('does not truncate', output => {
       const three = {...apps[0], id: '0'.repeat(80), name: 'supertable-test-3'}
       cli.table(apps.concat(three), columns, {filter: 'id=0', 'no-truncate': true})
-      expect(output.stdout).to.equal(`| ID${ws.padEnd(78)} Name${ws.padEnd(14)}
-| ${''.padEnd(three.id.length, '-')} -----------------${ws}
-| ${three.id} supertable-test-3${ws}\n`)
+      expect(output.stdout).to.equal(` ID${ws.padEnd(78)} Name${ws.padEnd(14)}
+ ${''.padEnd(three.id.length, '─')} ─────────────────${ws}
+ ${three.id} supertable-test-3${ws}\n`)
     })
   })
 
@@ -275,10 +287,10 @@ describe('styled/table', () => {
     .stdout()
     .end('ignores header case', output => {
       cli.table(apps, columns, {columns: 'iD,Name', filter: 'nAMe=supertable-test', sort: '-ID'})
-      expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
-| --- -----------------${ws}
-| 321 supertable-test-2${ws}
-| 123 supertable-test-1${ws}\n`)
+      expect(output.stdout).to.equal(` ID  Name${ws.padEnd(14)}
+ ─── ─────────────────${ws}
+ 321 supertable-test-2${ws}
+ 123 supertable-test-1${ws}\n`)
     })
 
     fancy
@@ -294,12 +306,12 @@ describe('styled/table', () => {
       }
 
       cli.table(apps.concat(app3 as any), columns, {sort: '-ID'})
-      expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
-| --- -----------------${ws}
-| 456 supertable-test${ws.padEnd(3)}
-|     3${ws.padEnd(17)}
-| 321 supertable-test-2${ws}
-| 123 supertable-test-1${ws}\n`)
+      expect(output.stdout).to.equal(` ID  Name${ws.padEnd(14)}
+ ─── ─────────────────${ws}
+ 456 supertable-test${ws.padEnd(3)}
+     3${ws.padEnd(17)}
+ 321 supertable-test-2${ws}
+ 123 supertable-test-1${ws}\n`)
     })
   })
 })

--- a/test/styled/table.test.ts
+++ b/test/styled/table.test.ts
@@ -90,9 +90,10 @@ describe('styled/table', () => {
   .stdout()
   .end('displays table', output => {
     cli.table(apps, columns)
-    expect(output.stdout).to.equal(`ID  Name${ws.padEnd(14)}
-123 supertable-test-1${ws}
-321 supertable-test-2${ws}\n`)
+    expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
+| --- -----------------${ws}
+| 123 supertable-test-1${ws}
+| 321 supertable-test-2${ws}\n`)
   })
 
   describe('columns', () => {
@@ -100,16 +101,17 @@ describe('styled/table', () => {
     .stdout()
     .end('use header value for id', output => {
       cli.table(apps, columns)
-      expect(output.stdout.slice(0, 2)).to.equal('ID')
+      expect(output.stdout.slice(2, 4)).to.equal('ID')
     })
 
     fancy
     .stdout()
     .end('shows extended columns/uses get() for value', output => {
       cli.table(apps, columns, {extended: true})
-      expect(output.stdout).to.equal(`${extendedHeader}
-123 supertable-test-1 https://supertable-test-1.herokuapp.com/ heroku-16${ws}
-321 supertable-test-2 https://supertable-test-2.herokuapp.com/ heroku-16${ws}\n`)
+      expect(output.stdout).to.equal(`|${ws}${extendedHeader}
+| --- ----------------- ---------------------------------------- ---------${ws}
+| 123 supertable-test-1 https://supertable-test-1.herokuapp.com/ heroku-16${ws}
+| 321 supertable-test-2 https://supertable-test-2.herokuapp.com/ heroku-16${ws}\n`)
     })
   })
 
@@ -125,17 +127,18 @@ describe('styled/table', () => {
     .stdout()
     .end('skips header', output => {
       cli.table(apps, columns, {'no-header': true})
-      expect(output.stdout).to.equal(`123 supertable-test-1${ws}
-321 supertable-test-2${ws}\n`)
+      expect(output.stdout).to.equal(`| 123 supertable-test-1${ws}
+| 321 supertable-test-2${ws}\n`)
     })
 
     fancy
     .stdout()
     .end('only displays given columns', output => {
       cli.table(apps, columns, {columns: 'id'})
-      expect(output.stdout).to.equal(`ID${ws}${ws}
-123${ws}
-321${ws}\n`)
+      expect(output.stdout).to.equal(`| ID${ws}${ws}
+| ---${ws}
+| 123${ws}
+| 321${ws}\n`)
     })
 
     fancy
@@ -225,17 +228,19 @@ describe('styled/table', () => {
     .stdout()
     .end('sorts by property', output => {
       cli.table(apps, columns, {sort: '-name'})
-      expect(output.stdout).to.equal(`ID  Name${ws.padEnd(14)}
-321 supertable-test-2${ws}
-123 supertable-test-1${ws}\n`)
+      expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
+| --- -----------------${ws}
+| 321 supertable-test-2${ws}
+| 123 supertable-test-1${ws}\n`)
     })
 
     fancy
     .stdout()
     .end('filters by property & value (partial string match)', output => {
       cli.table(apps, columns, {filter: 'id=123'})
-      expect(output.stdout).to.equal(`ID  Name${ws.padEnd(14)}
-123 supertable-test-1${ws}\n`)
+      expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
+| --- -----------------${ws}
+| 123 supertable-test-1${ws}\n`)
     })
 
     fancy
@@ -243,8 +248,9 @@ describe('styled/table', () => {
     .end('does not truncate', output => {
       const three = {...apps[0], id: '0'.repeat(80), name: 'supertable-test-3'}
       cli.table(apps.concat(three), columns, {filter: 'id=0', 'no-truncate': true})
-      expect(output.stdout).to.equal(`ID${ws.padEnd(78)} Name${ws.padEnd(14)}
-${three.id} supertable-test-3${ws}\n`)
+      expect(output.stdout).to.equal(`| ID${ws.padEnd(78)} Name${ws.padEnd(14)}
+| ${''.padEnd(three.id.length, '-')} -----------------${ws}
+| ${three.id} supertable-test-3${ws}\n`)
     })
   })
 
@@ -269,9 +275,10 @@ ${three.id} supertable-test-3${ws}\n`)
     .stdout()
     .end('ignores header case', output => {
       cli.table(apps, columns, {columns: 'iD,Name', filter: 'nAMe=supertable-test', sort: '-ID'})
-      expect(output.stdout).to.equal(`ID  Name${ws.padEnd(14)}
-321 supertable-test-2${ws}
-123 supertable-test-1${ws}\n`)
+      expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
+| --- -----------------${ws}
+| 321 supertable-test-2${ws}
+| 123 supertable-test-1${ws}\n`)
     })
 
     fancy
@@ -287,11 +294,12 @@ ${three.id} supertable-test-3${ws}\n`)
       }
 
       cli.table(apps.concat(app3 as any), columns, {sort: '-ID'})
-      expect(output.stdout).to.equal(`ID  Name${ws.padEnd(14)}
-456 supertable-test${ws.padEnd(3)}
-    3${ws.padEnd(17)}
-321 supertable-test-2${ws}
-123 supertable-test-1${ws}\n`)
+      expect(output.stdout).to.equal(`| ID  Name${ws.padEnd(14)}
+| --- -----------------${ws}
+| 456 supertable-test${ws.padEnd(3)}
+|     3${ws.padEnd(17)}
+| 321 supertable-test-2${ws}
+| 123 supertable-test-1${ws}\n`)
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Makes the table output more readable and allows adding a title with a divider to a table.

#### Before
![image](https://user-images.githubusercontent.com/1084688/119568602-a3b35c80-bd7b-11eb-8e39-0a2d1a27e068.png)

#### After
![image](https://user-images.githubusercontent.com/1084688/119568271-50d9a500-bd7b-11eb-9a7e-5de8eab2cc65.png)

### GUS Work Item
@W-9103917@