### PR TITLE
fix: makes the max terminal width for tables correct on Windows machines

### DIFF
--- a/src/styled/table.ts
+++ b/src/styled/table.ts
@@ -198,7 +198,7 @@ class Table<T extends object> {
       col.width = col.maxWidth!
     }
     // terminal width
-    const maxWidth = stdtermwidth
+    const maxWidth = stdtermwidth - 2
     // truncation logic
     const shouldShorten = () => {
       // don't shorten if full mode
@@ -259,7 +259,7 @@ class Table<T extends object> {
       // print header dividers
       let dividers = options.rowStart
       for (const col of columns) {
-        const divider = ''.padEnd(col.maxWidth! - 1, '─') + ' '
+        const divider = ''.padEnd(col.width! - 1, '─') + ' '
         dividers += divider.padEnd(col.width!)
       }
       options.printLine(chalk.bold(dividers))


### PR DESCRIPTION
# What does this do?
* Changes to use the column width, instead of max width, to build the header dividers.
* Makes the terminal width for tables 2 characters shorter to accommodate for the Windows Terminal.

Without this change:
![image](https://user-images.githubusercontent.com/1084688/124814395-ef892200-df33-11eb-80c1-85a63ce28492.png)

With this change:
![image](https://user-images.githubusercontent.com/1084688/124814430-fd3ea780-df33-11eb-96d7-11f593246bda.png)
