### PR TITLE
fix: calculate correct size for table header with full-width text

### DIFF
--- a/src/styled/table.ts
+++ b/src/styled/table.ts
@@ -252,7 +252,8 @@ class Table<T extends object> {
       let headers = options.rowStart
       for (const col of columns) {
         const header = col.header!
-        headers += header.padEnd(col.width!)
+        const colWidth = col.width! - sw(header) + header.length
+        headers += header.padEnd(colWidth)
       }
       options.printLine(chalk.bold(headers))
 


### PR DESCRIPTION
When there is any full-width text in the table header , the column size would be wrong.

Before:

<img width="493" alt="Snipaste_2021-07-19_11-45-33" src="https://user-images.githubusercontent.com/8638535/126100108-456f81f5-8882-4e02-bc29-6c81eb619aa4.png">

Fixed:

<img width="481" alt="Snipaste_2021-07-19_11-46-08" src="https://user-images.githubusercontent.com/8638535/126100121-2fed1670-6c30-4dbb-837e-362eec9648a4.png">
