### PR TITLE
Make url formatting helper available

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ await cli.url('sometext', 'https://google.com')
 
 ![url demo](assets/url.gif)
 
+# cli.formatUrl(text, uri)
+
+Format a hyperlink (if supported in the terminal). Useful when you want to make part of a line clickable.
+
+```typescript
+await cli.formatUrl('sometext', 'https://google.com')
+// returns sometext with hyperlink escape characters in supported terminals
+// returns https://google.com in unsupported terminals
+```
+
 # cli.open
 
 Open a url in the browser

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,13 +84,17 @@ export const ux = {
   },
 
   url(text: string, uri: string, params = {}) {
+    this.log(this.formatUrl(text, uri, params))
+  },
+
+  formatUrl(text: string, uri: string, params = {}) {
     const supports = require('supports-hyperlinks')
     if (supports.stdout) {
       const hyperlinker = require('hyperlinker')
-      this.log(hyperlinker(text, uri, params))
-    } else {
-      this.log(uri)
+      return hyperlinker(text, uri, params)
     }
+
+    return uri
   },
 
   annotation(text: string, annotation: string) {

--- a/test/format-url.test.ts
+++ b/test/format-url.test.ts
@@ -1,0 +1,12 @@
+import ux from '../src'
+
+import {expect, fancy} from './fancy'
+
+process.env.FORCE_HYPERLINK = '1'
+
+describe('prompt', () => {
+  fancy
+  .it('formats hyperlinks for rendering', async () => {
+    expect(ux.formatUrl('sometext', 'https://google.com')).to.contain('ttps://google.com\u0007sometext')
+  })
+})


### PR DESCRIPTION
Why: So that making part of a line a clickable url is possible.
