### PR TITLE
Provide proper typings for cli.progress()

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/clean-stack": "^2.1.1",
+    "@types/cli-progress": "^3.4.0",
     "@types/extract-stack": "^2.0.0",
     "@types/fs-extra": "^8.1",
     "@types/js-yaml": "^3.12.1",

--- a/src/styled/progress.ts
+++ b/src/styled/progress.ts
@@ -1,13 +1,9 @@
 // 3pp
 const cliProgress = require('cli-progress')
 
-export default function progress(options?: any): any {
-  // if no options passed, create empty options
-  if (!options) {
-    options = {}
-  }
+export default function progress(options: cliProgress.Options = {}): cliProgress.SingleBar {
   // set noTTYOutput for options
-  options.noTTYOutput = Boolean(process.env.TERM === 'dumb' || !process.stdin.isTTY)
+  options.noTTYOutput = options.noTTYOutput || Boolean(process.env.TERM === 'dumb' || !process.stdin.isTTY)
 
   return new cliProgress.SingleBar(options)
 }


### PR DESCRIPTION
Hi! 👋

Firstly, thanks for your work on this project! 🙂

At the moment, cli.progress() takes an option argument of any and returns any. This makes it difficult to validate which options are valid and which operations are available on the result of the function.

There may be a reason that any is specified here. But if it was an oversight, this PR should resolve the issue.